### PR TITLE
Disables Spring Boot banner in application

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.application.name=cruddemo
 spring.datasource.url=jdbc:mysql://localhost:3306/student_tracker
 spring.datasource.username=springstudent
 spring.datasource.password=springstudent
+
+# Turn of the Spring Boot banner
+spring.main.banner-mode=off


### PR DESCRIPTION
Adds a configuration to turn off the Spring Boot startup banner by setting `spring.main.banner-mode=off` in the application properties file. This can improve log readability during application startup.