### PR TITLE
Set root logging level to WARN

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.password=springstudent
 
 # Turn of the Spring Boot banner
 spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn


### PR DESCRIPTION
Adjusts the root logging level to WARN to reduce log verbosity, helping to focus on warnings and errors. Also ensures proper formatting by adding a newline at the end of the file.