### PR TITLE
Adds method to delete all students

### DIFF
--- a/src/main/java/com/dj/cruddemo/CruddemoApplication.java
+++ b/src/main/java/com/dj/cruddemo/CruddemoApplication.java
@@ -31,8 +31,14 @@ public class CruddemoApplication {
 
 			// updateStudent(studentDAO);
 
-			deleteStudent(studentDAO);
+			// deleteStudent(studentDAO);
+
+			deleteAll(studentDAO);
 		};
+	}
+
+	private void deleteAll(StudentDAO studentDAO) {
+		studentDAO.deleteAll();
 	}
 
 	private void deleteStudent(StudentDAO studentDAO) {

--- a/src/main/java/com/dj/cruddemo/dao/StudentDAO.java
+++ b/src/main/java/com/dj/cruddemo/dao/StudentDAO.java
@@ -18,4 +18,6 @@ public interface StudentDAO {
 
     void delete(int id);
 
+    int deleteAll();
+
 }

--- a/src/main/java/com/dj/cruddemo/dao/StudentDAOImpl.java
+++ b/src/main/java/com/dj/cruddemo/dao/StudentDAOImpl.java
@@ -70,4 +70,14 @@ public class StudentDAOImpl implements StudentDAO{
         entityManager.remove(theStudent);
     }
 
+    @Override
+    @Transactional
+    public int deleteAll() {
+        int numRowsDeleted = entityManager.createQuery("DELETE FROM Student").executeUpdate();
+        // return the number of rows deleted
+        System.out.println("Number of rows deleted: " + numRowsDeleted);
+        // return the number of rows deleted
+        return numRowsDeleted;
+    }
+
 }


### PR DESCRIPTION
Introduces a `deleteAll` method in the DAO layer to remove all student records from the database. Updates the implementation with a transactional query and logs the number of rows deleted. Replaces the single student deletion call in the application entry point with the new method, improving functionality for bulk deletions.